### PR TITLE
Only one F remains.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,5 +28,12 @@
         "ext-xdebug": "~2@stable",
         "doctrine/orm": "~2",
         "phpunit/phpunit": "4.7.*@dev"
+    },
+    "archive": {
+        "exclude": [
+            "phpunit.xml",
+            "target",
+            "tests"
+        ]
     }
 }

--- a/lib/Doctrine/DBAL/Platforms/CassandraPlatform.php
+++ b/lib/Doctrine/DBAL/Platforms/CassandraPlatform.php
@@ -112,6 +112,11 @@ class CassandraPlatform extends AbstractPlatform
         return 'timestamp';
     }
 
+    public function getDateTimeFormatStringToDatabase()
+    {
+        return 'Y-m-d H:i:sO';
+    }
+
     /**
      * {@inheritDoc}
      */

--- a/lib/Doctrine/DBAL/Types/CassandraDateTimeType.php
+++ b/lib/Doctrine/DBAL/Types/CassandraDateTimeType.php
@@ -18,6 +18,7 @@
  */
 
 namespace CassandraPDO4Doctrine\Doctrine\DBAL\Types;
+use CassandraPDO4Doctrine\Doctrine\DBAL\Platforms\CassandraPlatform;
 use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Doctrine\DBAL\Types\DateTimeType;
 use Doctrine\DBAL\Types\ConversionException;
@@ -63,5 +64,30 @@ class CassandraDateTimeType extends DateTimeType
 
         return $val;
     }
+
+    public function convertToDatabaseValue($value, CassandraPlatform $platform)
+    {
+
+        if ($value === null || is_string($value) ) {
+            return $value;
+        }
+
+        $val = null;
+
+        if ( $value instanceof \DateTime) {
+            $val = $value->format($platform->getDateTimeFormatStringToDatabase());
+        }
+
+        if ( ! $val) {
+            throw ConversionException::conversionFailedFormat(
+                $value,
+                $this->getName(),
+                $platform->getDateTimeFormatStringToDatabase()
+            );
+        }
+
+        return $val;
+    }
+
 
 }

--- a/tests/data/db_data.cql3
+++ b/tests/data/db_data.cql3
@@ -2,6 +2,6 @@ USE test_cp4d;
 
 TRUNCATE product;
 
-INSERT INTO product (name, price, description, created) VALUES ('prod1', 1.00,'prod #1 desc',dateof(now()));
-INSERT INTO product (name, price, description, created) VALUES ('prod2', 2.00,'prod #2 desc',dateof(now()));
-INSERT INTO product (name, price, description, created) VALUES ('prod3', 3.00,'prod #3 desc',dateof(now()));
+INSERT INTO product (name, price, description, created) VALUES ('prod1', 1.00,'prod #1 desc','2015-01-01 01:01:01+0000');
+INSERT INTO product (name, price, description, created) VALUES ('prod2', 2.00,'prod #2 desc','2015-01-02 01:01:01+0000');
+INSERT INTO product (name, price, description, created) VALUES ('prod3', 1.12,'prod #3 desc','2015-01-03 01:01:01+0000');

--- a/tests/src/CP4DBaseTestCase.php
+++ b/tests/src/CP4DBaseTestCase.php
@@ -16,17 +16,17 @@ class CP4DBaseTestCase extends \PHPUnit_Framework_TestCase {
 
     static public function setUpBeforeClass() {
         $D = self::_getDataDir();
-        //system("cqlsh < {$D}/db_create.cql3");
+        system("cqlsh < {$D}/db_create.cql3");
     }
 
     static public function tearDownAfterClass() {
         $D = self::_getDataDir();
-       // system("cqlsh < {$D}/db_drop.cql3");
+        system("cqlsh < {$D}/db_drop.cql3");
     }
 
     public function setUp() {
         $D = self::_getDataDir();
-      //  system("cqlsh < {$D}/db_data.cql3");
+        system("cqlsh < {$D}/db_data.cql3");
     }
 
     /**

--- a/tests/src/CP4DTest.php
+++ b/tests/src/CP4DTest.php
@@ -76,7 +76,6 @@ class CP4DTest extends CP4DBaseTestCase {
         $em = $this->getEntityManager();
         $query = $em->createQuery("SELECT count(p.name) FROM " . Product::className() . " p WHERE p.name= 'A Foo Bar' ORDER BY p.created ASC");
         $cnt = $query->getResult();
-        var_dump($cnt);
         $this->assertEquals($cnt,[0=>[1=>1]]);
     }
 

--- a/tests/src/CP4DTest.php
+++ b/tests/src/CP4DTest.php
@@ -22,14 +22,13 @@ class CP4DTest extends CP4DBaseTestCase {
         $repo = $this->getRepository(Product::className());
         /** @var Product[] $products */
         $products = $repo->findBy(
-            array('name' => 'A Foo Bar'),
+            array('name' => 'prod1'),
             array('created' => 'ASC')
         );
 
         $this->assertNotEmpty($products);
         $this->assertInstanceOf(Product::className(),$products[0]);
-        // FIXME: date in far future
-        $this->assertGreaterThan($products[0]->getCreated(),new \DateTime());
+        $this->assertEquals(new \DateTime('2015-01-01 01:01:01+0000'),$products[0]->getCreated());
     }
 
     public function testFindBySQL() {
@@ -44,14 +43,20 @@ class CP4DTest extends CP4DBaseTestCase {
     public function testFindByQueryBuilder() {
         $repo = $this->getRepository(Product::className());
         $query = $repo->createQueryBuilder('p')
+
             ->where('p.name =:name')
+            ->setParameter('name', 'prod3')
+
             ->andWhere('p.created =:created')
+            ->setParameter('created', new \DateTime('2015-01-03 01:01:01+0000'),'cassandra_datetime')
+
+            // FIXME: Uncommenting this makes result empty
             ->andWhere('p.price =:price')
             ->setParameter('price', 1.12,'cassandra_float')//must specify type explicitly
-            ->setParameter('name', 'A Foo Bar')
-            ->setParameter('created', date('Y-m-d'))
+
             ->orderBy('p.created', 'ASC')
             ->getQuery();
+
         $products = $query->getResult();
 
         $this->assertNotEmpty($products);
@@ -65,7 +70,7 @@ class CP4DTest extends CP4DBaseTestCase {
         $rsm->addScalarResult('price', 'price');
 
         $query = $em->createNativeQuery('SELECT * FROM product WHERE name = ?', $rsm);
-        $query->setParameter(1, 'A Foo Bar');
+        $query->setParameter(1, 'prod2');
         $products = $query->getResult();
 
         $this->assertNotEmpty($products);
@@ -74,7 +79,7 @@ class CP4DTest extends CP4DBaseTestCase {
 
     public function testCounting() {
         $em = $this->getEntityManager();
-        $query = $em->createQuery("SELECT count(p.name) FROM " . Product::className() . " p WHERE p.name= 'A Foo Bar' ORDER BY p.created ASC");
+        $query = $em->createQuery("SELECT count(p.name) FROM " . Product::className() . " p WHERE p.name= 'prod2' ORDER BY p.created ASC");
         $cnt = $query->getResult();
         $this->assertEquals($cnt,[0=>[1=>1]]);
     }


### PR DESCRIPTION
Please review my addition of one-way format function for date. I feel it's a bit smelly, but can't come up with any other idea. What is documented / standartized way of dealing with dates and timezones in your experience, workshop etc ?

Why did you comment out database fixture creation/cleanup ? Why put in code values different from DB script ?

Tests, among other purposes, are intended for user who freshly downloads a package to be capable of quickly examining it, without digging into sysadmin matters, figuring out how to configure database etc.

Running every test with known state is crucial. No permanent test data. No dependency on running order. I researched DBunit, it can prepare little datasets for every test, but it itself needs Cassandra adapter: https://github.com/sebastianbergmann/dbunit/issues/154

Do you have remote Cassandra with permanent test data ? Why not local ? Disabled `system()` function ? 
